### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/modules/networking.nix
+++ b/modules/networking.nix
@@ -29,7 +29,7 @@
 
         # if packets are still dropped, they will show up in dmesg
         logReversePathDrops = true;
-        # wireguard trips rpfilter up https://nixos.wiki/wiki/WireGuard#Setting_up_WireGuard_with_NetworkManager
+        # wireguard trips rpfilter up https://wiki.nixos.org/wiki/WireGuard#Setting_up_WireGuard_with_NetworkManager
         extraCommands = ''
           ip46tables -t mangle -I nixos-fw-rpfilter -p udp -m udp --sport ${toString wgPort} -j RETURN
           ip46tables -t mangle -I nixos-fw-rpfilter -p udp -m udp --dport ${toString wgPort} -j RETURN

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -20,7 +20,7 @@ rec {
 
       ## More Info
       - [Rust language](https://www.rust-lang.org/) - https://www.rust-lang.org/
-      - [Rust on the NixOS Wiki](https://nixos.wiki/wiki/Rust) - https://nixos.wiki/wiki/Rust
+      - [Rust on the NixOS Wiki](https://wiki.nixos.org/wiki/Rust) - https://wiki.nixos.org/wiki/Rust
     '';
   };
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️